### PR TITLE
Remove !important from font-family

### DIFF
--- a/app/assets/stylesheets/tmix-icon.css
+++ b/app/assets/stylesheets/tmix-icon.css
@@ -10,8 +10,6 @@
 }
 
 i {
-  /* use !important to prevent issues with browser extensions that change fonts */
-  font-family: 'tmix-icon' !important;
   font-family: 'tmix-icon';
   speak: none;
   font-style: normal;


### PR DESCRIPTION
Can't show fontawesome's font when specify "!important"
