### PR TITLE
Add aliases to tmix-print-area-towel icons

### DIFF
--- a/app/assets/stylesheets/tmix-icon.css
+++ b/app/assets/stylesheets/tmix-icon.css
@@ -251,10 +251,10 @@ i {
 .tmix-print-area-pull-parka-front:before {
   content: "\e93c";
 }
-.tmix-print-area-towel-left:before {
+.tmix-print-area-towel-left:before, .tmix-print-area-towel-back:before {
   content: "\e93d";
 }
-.tmix-print-area-towel-right:before {
+.tmix-print-area-towel-right:before, .tmix-print-area-towel-front:before {
   content: "\e93e";
 }
 .tmix-print-area-tshirt-back:before {


### PR DESCRIPTION
Add aliases.

tmix-print-area-towel-right -> tmix-print-area-towel-front
tmix-print-area-towel-left -> tmix-print-area-towel-back