### PR TITLE
Create rake task to remove executable flag from files

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,1 +1,7 @@
 require "bundler/gem_tasks"
+
+task :remove_execute_flags do
+  Dir.glob('**/*.{eot,svg,ttf,woff,html,css}').each do |filename|
+    `chmod -x #{filename}` if File.executable?(filename)
+  end
+end


### PR DESCRIPTION
Files generated by IcoMoon, for example, svg, woff, html and so on are set the executable flag by unknown reason.
So, created simple rake task to remove executable flags that files.