### PR TITLE
Publish npm as @spice-life/icon

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,19 @@
+{
+  "name": "@spice-life/icon",
+  "version": "1.1.0",
+  "description": "Formally tmix-icon-rails",
+  "main": "index.js",
+  "files": [
+    "app", "script"
+  ],
+  "repository": {
+    "type": "git",
+    "url": "git+ssh://git@github.com/spice-life/tmix-icon-rails.git"
+  },
+  "author": "Takaya Kobayashi <kobayashi@spicelife.jp>",
+  "license": "MIT and OFL",
+  "bugs": {
+    "url": "https://github.com/spice-life/tmix-icon-rails/issues"
+  },
+  "homepage": "https://github.com/spice-life/tmix-icon-rails#readme"
+}

--- a/script/generate.js
+++ b/script/generate.js
@@ -1,0 +1,15 @@
+#!/usr/bin/env node
+const {readFileSync} = require('fs')
+const {resolve} = require('path')
+const {URL} = require('url')
+const host = process.argv[2]
+
+const css = readFileSync(
+  resolve(__dirname, '../app/assets/stylesheets/tmix-icon.css')
+).toString().replace(/font-url\('([^\s]*)'\)/g, (_, path) => {
+  const url = new URL(host)
+  url.pathname = resolve(url.pathname, path)
+  return `url('${url.toString()}')`
+})
+
+console.log(css)


### PR DESCRIPTION
* https://www.npmjs.com/package/@spice-life/icon として公開しました
* rails の `font-url` になっているところを配信用に置換するスクリプトもバンドルするようにしました